### PR TITLE
Better typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@
 - URL persistence is optional and separate
 - First class React Native support
 
----
-
 ### Installation
 
 ```js
@@ -62,8 +60,6 @@ or
 ```js
 yarn add @mobx-state-machine-router/core
 ```
-
----
 
 ### Basics
 
@@ -101,6 +97,17 @@ const states: TStates<STATE, ACTION> = {
   }
 };
 
+// initialize router
+const stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
+  states,
+  currentState: {
+    name: STATE.HOME,
+    params: {
+      activity: null,
+    },
+  },
+});
+
 stateMachineRouter.emit(ACTION.goToWork);
 
 console.log(stateMachineRouter.currentState.name);
@@ -109,8 +116,6 @@ console.log(stateMachineRouter.currentState.name);
 stateMachineRouter.emit(ACTION.goToWork);
 > 'WORK' // ==> ignored as only the HOME state is allowed to "goToWork"
 ```
-
----
 
 ### Passing Params
 
@@ -129,8 +134,6 @@ console.log(stateMachineRouter.currentState);
 }
 ```
 
----
-
 ### Observing state changes
 
 Observing state changes is done using mobx's `observe`, and more granularly using `observeParam`:
@@ -142,8 +145,6 @@ import { observeParam } from '@mobx-state-machine-router/core';
 observe(stateMachineRouter, 'currentState', () => {});
 observeParam(stateMachineRouter, 'currentState', 'method', () => {});
 ```
-
----
 
 ### Intercepting state changes
 
@@ -178,8 +179,6 @@ interceptAsync(stateMachineRouter, 'currentState', async (change) => {
 });
 ```
 
----
-
 ### Rendering UI Elements
 
 The Router can be accessed in using React's Context API or other means. Components wrapped in observer will re-render whenever state changes.
@@ -196,5 +195,26 @@ export const App = observer(() => {
     { currentState.name === STATE.ABOUT && <About> }
     </>
   )
+});
+```
+
+### Persistence
+
+1. Install:
+
+`yarn add @mobx-state-machine-router/url-persistence history`
+
+2. Initialize with your choice of `history`
+
+```typescript
+const stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
+  states,
+  currentState: {
+    name: STATE.HOME,
+    params: {
+      activity: null,
+    },
+  },
+  persistence: URLPersistence<STATE, TParams2, ACTION>(createHashHistory()),
 });
 ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobx-state-machine-router/core",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "State Machine routing for Mobx",
   "author": "Anzor Bashkhaz",
   "email": "anzorb@gmail.com",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobx-state-machine-router/core",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "State Machine routing for Mobx",
   "author": "Anzor Bashkhaz",
   "email": "anzorb@gmail.com",

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -1,31 +1,55 @@
 import { observe, intercept, observable } from 'mobx';
 import interceptAsync from 'mobx-async-intercept';
-import MobxStateMachineRouter from '../src';
+import MobxStateMachineRouter, { TStates } from '../src';
 import { observeParam } from './index';
 
-const ms = ms => new Promise(resolve => setTimeout(resolve, ms));
+const ms = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const states = {
-  HOME: {
+enum STATE {
+  HOME = 'HOME',
+  WORK = 'WORK',
+  'WORK/LUNCHROOM' = 'WORK/LUNCHROOM',
+}
+
+enum ACTION {
+  goToWork = 'goToWork',
+  clean = 'clean',
+  slack = 'slack',
+  goHome = 'goHome',
+  getFood = 'getFood',
+  eat = 'eat',
+  backToWork = 'backToWork',
+  tiredAfterLunchGoHome = 'tiredAfterLunchGoHome',
+}
+
+type TParams = {
+  activity?: string | null;
+};
+
+const states: TStates<STATE, ACTION> = {
+  [STATE.HOME]: {
     actions: {
-      goToWork: 'WORK',
-      clean: 'HOME'
-    }
+      [ACTION.goToWork]: STATE.WORK,
+      [ACTION.clean]: STATE.HOME,
+    },
+    url: '/',
   },
-  WORK: {
+  [STATE.WORK]: {
     actions: {
-      goHome: 'HOME',
-      slack: 'WORK',
-      getFood: 'WORK/LUNCHROOM'
-    }
+      [ACTION.goHome]: STATE.HOME,
+      [ACTION.slack]: STATE.WORK,
+      [ACTION.getFood]: STATE['WORK/LUNCHROOM'],
+    },
+    url: '/work',
   },
-  'WORK/LUNCHROOM': {
+  [STATE['WORK/LUNCHROOM']]: {
     actions: {
-      eat: 'WORK/LUNCHROOM',
-      backToWork: 'WORK',
-      tiredAfterLunchGoHome: 'HOME'
-    }
-  }
+      [ACTION.eat]: STATE['WORK/LUNCHROOM'],
+      [ACTION.backToWork]: STATE.WORK,
+      [ACTION.tiredAfterLunchGoHome]: STATE.HOME,
+    },
+    url: '/work/lunchroom',
+  },
 };
 
 describe('init', () => {
@@ -34,52 +58,52 @@ describe('init', () => {
   });
 
   it('should allow to create instance with null startState or query', () => {
-    const stateMachineRouter = MobxStateMachineRouter({
-      states
+    const stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
+      states,
     });
-    expect(stateMachineRouter.currentState.name).toBe('HOME');
+    expect(stateMachineRouter.currentState.name).toBe(STATE.HOME);
     expect(stateMachineRouter.currentState.params).toEqual({});
   });
 
   it('should allow to create instance with different startStates + validation', () => {
-    const stateMachineRouter = MobxStateMachineRouter({
+    const stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
       states,
       currentState: {
-        name: 'AAAH',
+        name: 'AAAH' as STATE,
         params: {
-          activity: null
-        }
-      }
+          activity: null,
+        },
+      },
     });
     expect(stateMachineRouter.currentState.name).not.toBe('AAAH');
-    expect(stateMachineRouter.currentState.name).toBe('HOME');
+    expect(stateMachineRouter.currentState.name).toBe(STATE.HOME);
   });
 
   it('should allow to create instance with empty query', () => {
-    const stateMachineRouter = MobxStateMachineRouter({
+    const stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
       states,
       currentState: {
-        name: 'HOME',
-        params: {}
-      }
+        name: STATE.HOME,
+        params: {},
+      },
     });
     expect(Object.keys(stateMachineRouter.currentState.params).length).toBe(0);
   });
 
   it('should allow to create instance with queries and setup observables for them', () => {
-    const stateMachineRouter = MobxStateMachineRouter({
+    const stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
       states,
       currentState: {
-        name: 'HOME',
+        name: STATE.HOME,
         params: {
-          activity: 'biking'
-        }
-      }
+          activity: 'biking',
+        },
+      },
     });
     const spy = jest.fn();
     observe(stateMachineRouter, 'currentState', spy);
     expect(stateMachineRouter.currentState.params.activity).toBe('biking');
-    stateMachineRouter.emit('goToWork', { activity: 'walking' });
+    stateMachineRouter.emit(ACTION.goToWork, { activity: 'walking' });
     expect(spy).toHaveBeenCalled();
   });
 });
@@ -87,14 +111,14 @@ describe('init', () => {
 describe('MobX state machine router', () => {
   let stateMachineRouter;
   beforeEach(() => {
-    stateMachineRouter = MobxStateMachineRouter({
+    stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
       states,
       currentState: {
-        name: 'HOME',
+        name: STATE.HOME,
         params: {
-          activity: ''
-        }
-      }
+          activity: '',
+        },
+      },
     });
   });
 
@@ -107,42 +131,42 @@ describe('MobX state machine router', () => {
 
   describe('basics', () => {
     it('should init', () => {
-      expect(stateMachineRouter.currentState.name).toBe('HOME');
+      expect(stateMachineRouter.currentState.name).toBe(STATE.HOME);
     });
 
     it('should do basic routing', () => {
-      stateMachineRouter.emit('goToWork');
+      stateMachineRouter.emit(ACTION.goToWork);
       expect(stateMachineRouter.currentState.name).toBe('WORK');
     });
 
     it('should update query params', () => {
-      stateMachineRouter.emit('goToWork');
-      stateMachineRouter.emit('slack', { activity: 'daydreaming' });
+      stateMachineRouter.emit(ACTION.goToWork);
+      stateMachineRouter.emit(ACTION.slack, { activity: 'daydreaming' });
       expect(stateMachineRouter.currentState.name).toBe('WORK');
       expect(stateMachineRouter.currentState.params.activity).toEqual(
         'daydreaming'
       );
-      stateMachineRouter.emit('goHome', {
+      stateMachineRouter.emit(ACTION.goHome, {
         ...stateMachineRouter.currentState.params,
-        method: 'car'
+        method: 'car',
       });
-      expect(stateMachineRouter.currentState.name).toBe('HOME');
+      expect(stateMachineRouter.currentState.name).toBe(STATE.HOME);
       expect(stateMachineRouter.currentState.params).toEqual({
         activity: 'daydreaming',
-        method: 'car'
+        method: 'car',
       });
     });
 
     it('should nullify query params', () => {
-      stateMachineRouter.emit('goToWork');
-      stateMachineRouter.emit('slack', { activity: null });
+      stateMachineRouter.emit(ACTION.goToWork);
+      stateMachineRouter.emit(ACTION.slack, { activity: null });
       expect(stateMachineRouter.currentState.name).toBe('WORK');
       expect(stateMachineRouter.currentState.params.activity).toEqual(null);
     });
 
     it('should support child states', () => {
-      stateMachineRouter.emit('goToWork');
-      stateMachineRouter.emit('getFood', { coffee: true });
+      stateMachineRouter.emit(ACTION.goToWork);
+      stateMachineRouter.emit(ACTION.getFood, { coffee: true });
       expect(stateMachineRouter.currentState.name).toBe('WORK/LUNCHROOM');
       expect(stateMachineRouter.currentState.params.coffee).toEqual(true);
     });
@@ -150,49 +174,49 @@ describe('MobX state machine router', () => {
 
   describe('reactivity', () => {
     it('should allow us to listen to specific query changes', () => {
-      stateMachineRouter.emit('goToWork');
+      stateMachineRouter.emit(ACTION.goToWork);
       const listener = jest.fn();
       observe(stateMachineRouter, 'currentState', listener);
-      stateMachineRouter.emit('slack', { activity: 'ping-pong' });
+      stateMachineRouter.emit(ACTION.slack, { activity: 'ping-pong' });
       expect(listener).toHaveBeenCalled();
     });
 
     it('should not change state if resulting state does not exist', () => {
       const listener = jest.fn();
       observe(stateMachineRouter, 'currentState', listener);
-      stateMachineRouter.emit('slack', { activity: 'ping-pong' });
+      stateMachineRouter.emit(ACTION.slack, { activity: 'ping-pong' });
       expect(stateMachineRouter.currentState.params.activity).toBe('');
       expect(listener).not.toHaveBeenCalled();
     });
 
     it('should allow adding dynamic query params at runtime', () => {
       const listener = jest.fn();
-      stateMachineRouter.emit('goToWork');
-      stateMachineRouter.emit('slack', { mood: 'need-coffee' });
+      stateMachineRouter.emit(ACTION.goToWork);
+      stateMachineRouter.emit(ACTION.slack, { mood: 'need-coffee' });
       observe(stateMachineRouter, 'currentState', listener);
-      stateMachineRouter.emit('slack', { mood: 'so-many-jitters' });
+      stateMachineRouter.emit(ACTION.slack, { mood: 'so-many-jitters' });
       expect(listener).toHaveBeenCalled();
     });
 
     it('should allow listening to the whole query for changes', () => {
       const listener = jest.fn();
       observe(stateMachineRouter, 'currentState', listener);
-      stateMachineRouter.emit('goToWork');
+      stateMachineRouter.emit(ACTION.goToWork);
       expect(listener).toHaveBeenCalled();
     });
 
     it('should emit correct updates', () => {
-      stateMachineRouter.emit('goToWork');
+      stateMachineRouter.emit(ACTION.goToWork);
       const listener = jest.fn();
       observe(stateMachineRouter, 'currentState', listener);
-      stateMachineRouter.emit('slack', { activity: 'sleeping' });
+      stateMachineRouter.emit(ACTION.slack, { activity: 'sleeping' });
       expect(listener).toHaveBeenCalled();
     });
 
     it('should allow observing individual params', () => {
       const spy = jest.fn();
       observeParam(stateMachineRouter, 'currentState', 'activity', spy);
-      stateMachineRouter.emit('goToWork', { activity: 'crawling' });
+      stateMachineRouter.emit(ACTION.goToWork, { activity: 'crawling' });
       expect(spy).toHaveBeenCalled();
     });
   });
@@ -201,14 +225,14 @@ describe('MobX state machine router', () => {
 describe('intercepting state changes', () => {
   let stateMachineRouter;
   beforeEach(() => {
-    stateMachineRouter = MobxStateMachineRouter({
+    stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
       states,
       currentState: {
-        name: 'HOME',
+        name: STATE.HOME,
         params: {
-          activity: null
-        }
-      }
+          activity: null,
+        },
+      },
     });
   });
 
@@ -220,35 +244,35 @@ describe('intercepting state changes', () => {
   });
 
   it('should allow to intercept state change and override result state', () => {
-    intercept(stateMachineRouter, 'currentState', object => {
-      return { ...object, newValue: { ...object.newValue, name: 'HOME' } };
+    intercept(stateMachineRouter, 'currentState', (object) => {
+      return { ...object, newValue: { ...object.newValue, name: STATE.HOME } };
     });
-    stateMachineRouter.emit('goToWork');
-    expect(stateMachineRouter.currentState.name).toBe('HOME');
+    stateMachineRouter.emit(ACTION.goToWork);
+    expect(stateMachineRouter.currentState.name).toBe(STATE.HOME);
   });
 
   it('should allow to intercept state change and stop state change', () => {
-    intercept(stateMachineRouter, 'currentState', object => {
+    intercept(stateMachineRouter, 'currentState', (object) => {
       return null;
     });
-    stateMachineRouter.emit('goToWork');
-    expect(stateMachineRouter.currentState.name).toBe('HOME');
+    stateMachineRouter.emit(ACTION.goToWork);
+    expect(stateMachineRouter.currentState.name).toBe(STATE.HOME);
   });
 
-  it('should allow to async intercept', done => {
-    interceptAsync(stateMachineRouter, 'currentState', object => {
-      return new Promise(resolve => {
+  it('should allow to async intercept', (done) => {
+    interceptAsync(stateMachineRouter, 'currentState', (object) => {
+      return new Promise((resolve) => {
         setTimeout(() => {
           resolve({
             ...object,
-            newValue: { ...object.newValue, name: 'ERROR' }
+            newValue: { ...object.newValue, name: 'ERROR' },
           });
         }, 3);
       });
     });
-    stateMachineRouter.emit('goToWork', { activity: 'slack' });
+    stateMachineRouter.emit(ACTION.goToWork, { activity: 'slack' });
     setTimeout(() => {
-      expect(stateMachineRouter.currentState.name).toBe('HOME');
+      expect(stateMachineRouter.currentState.name).toBe(STATE.HOME);
     }, 0);
     setTimeout(() => {
       expect(stateMachineRouter.currentState.name).toBe('ERROR');
@@ -258,24 +282,24 @@ describe('intercepting state changes', () => {
   });
 
   it('should allow to async intercept to update param', async () => {
-    interceptAsync(stateMachineRouter, 'currentState', object => {
-      return new Promise(resolve => {
+    interceptAsync(stateMachineRouter, 'currentState', (object) => {
+      return new Promise((resolve) => {
         setTimeout(() => {
           resolve({
             ...object,
             newValue: {
               ...object.newValue,
-              params: { ...object.newValue.params, activity: 'working-hard' }
-            }
+              params: { ...object.newValue.params, activity: 'working-hard' },
+            },
           });
         }, 10);
       });
     });
 
-    stateMachineRouter.emit('goToWork', { activity: 'slack' });
+    stateMachineRouter.emit(ACTION.goToWork, { activity: 'slack' });
     await ms(1);
 
-    expect(stateMachineRouter.currentState.name).toBe('HOME');
+    expect(stateMachineRouter.currentState.name).toBe(STATE.HOME);
 
     await ms(30);
     expect(stateMachineRouter.currentState.name).toBe('WORK');

--- a/packages/url-persistence/package.json
+++ b/packages/url-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobx-state-machine-router/url-persistence",
-  "version": "2.0.0",
+  "version": "3.0.1",
   "description": "State Machine routing for Mobx",
   "author": "Anzor Bashkhaz",
   "email": "anzorb@gmail.com",

--- a/packages/url-persistence/src/index.test.ts
+++ b/packages/url-persistence/src/index.test.ts
@@ -1,35 +1,56 @@
 import { observe, intercept, toJS } from 'mobx';
 import { createHashHistory, Location } from 'history';
 import URLPersistence from '.';
-import { IMobxStateMachineRouter } from '../../core/src';
+import { IMobxStateMachineRouter, TStates } from '../../core/src';
 import MobxStateMachineRouter from '../../core/src';
 
-const ms = ms => new Promise(resolve => setTimeout(resolve, ms));
+const ms = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const states = {
-  HOME: {
+enum STATE {
+  HOME = 'HOME',
+  WORK = 'WORK',
+  'WORK/LUNCHROOM' = 'WORK/LUNCHROOM',
+}
+
+enum ACTION {
+  goToWork = 'goToWork',
+  clean = 'clean',
+  slack = 'slack',
+  goHome = 'goHome',
+  getFood = 'getFood',
+  eat = 'eat',
+  backToWork = 'backToWork',
+  tiredAfterLunchGoHome = 'tiredAfterLunchGoHome',
+}
+
+type TParams = {
+  activity?: string | null;
+};
+
+const states: TStates<STATE, ACTION> = {
+  [STATE.HOME]: {
     actions: {
-      goToWork: 'WORK',
-      clean: 'HOME'
+      [ACTION.goToWork]: STATE.WORK,
+      [ACTION.clean]: STATE.HOME,
     },
-    url: '/'
+    url: '/',
   },
-  WORK: {
+  [STATE.WORK]: {
     actions: {
-      goHome: 'HOME',
-      slack: 'WORK',
-      getFood: 'WORK/LUNCHROOM'
+      [ACTION.goHome]: STATE.HOME,
+      [ACTION.slack]: STATE.WORK,
+      [ACTION.getFood]: STATE['WORK/LUNCHROOM'],
     },
-    url: '/work'
+    url: '/work',
   },
-  'WORK/LUNCHROOM': {
+  [STATE['WORK/LUNCHROOM']]: {
     actions: {
-      eat: 'WORK/LUNCHROOM',
-      backToWork: 'WORK',
-      tiredAfterLunchGoHome: 'HOME'
+      [ACTION.eat]: STATE['WORK/LUNCHROOM'],
+      [ACTION.backToWork]: STATE.WORK,
+      [ACTION.tiredAfterLunchGoHome]: STATE.HOME,
     },
-    url: '/work/lunchroom'
-  }
+    url: '/work/lunchroom',
+  },
 };
 
 describe('URL Persistence', () => {
@@ -51,8 +72,8 @@ describe('URL Persistence', () => {
       name: '/hello',
       params: {
         what: 'world',
-        where: 'bla'
-      }
+        where: 'bla',
+      },
     });
   });
 
@@ -62,13 +83,13 @@ describe('URL Persistence', () => {
         name: 'new',
         params: {
           hola: 'amigos',
-          this: 'is'
-        }
+          this: 'is',
+        },
       },
       {
         new: {
-          url: '/new'
-        }
+          url: '/new',
+        },
       }
     );
     expect(window.location.hash).toEqual('#/new?hola=amigos&this=is');
@@ -87,15 +108,15 @@ describe('with URL persistence', () => {
   let persistence;
   beforeEach(() => {
     persistence = URLPersistence(createHashHistory());
-    stateMachineRouter = MobxStateMachineRouter({
+    stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
       states,
       currentState: {
-        name: 'HOME',
+        name: STATE.HOME,
         params: {
-          activity: null
-        }
+          activity: null,
+        },
       },
-      persistence
+      persistence,
     });
   });
 
@@ -108,17 +129,17 @@ describe('with URL persistence', () => {
 
   it('should do basic routing', () => {
     persistence = URLPersistence(createHashHistory());
-    stateMachineRouter = MobxStateMachineRouter({
+    stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
       states,
       currentState: {
-        name: 'HOME',
+        name: STATE.HOME,
         params: {
-          activity: null
-        }
+          activity: null,
+        },
       },
-      persistence
+      persistence,
     });
-    stateMachineRouter.emit('goToWork');
+    stateMachineRouter.emit(ACTION.goToWork);
     expect(window.location.hash).toBe('#/work');
   });
 
@@ -131,35 +152,35 @@ describe('with URL persistence', () => {
   });
 
   it('should update query params', () => {
-    stateMachineRouter.emit('goToWork');
-    stateMachineRouter.emit('slack', { activity: 'daydreaming' });
+    stateMachineRouter.emit(ACTION.goToWork);
+    stateMachineRouter.emit(ACTION.slack, { activity: 'daydreaming' });
     expect(window.location.hash).toBe('#/work?activity=daydreaming');
   });
 
   it('should nullify query params', () => {
-    stateMachineRouter.emit('goToWork');
-    stateMachineRouter.emit('slack', { activity: null });
+    stateMachineRouter.emit(ACTION.goToWork);
+    stateMachineRouter.emit(ACTION.slack, { activity: null });
     expect(window.location.hash).toBe('#/work');
   });
 
   it('should support child states', () => {
-    stateMachineRouter.emit('goToWork');
-    stateMachineRouter.emit('getFood', { coffee: true });
+    stateMachineRouter.emit(ACTION.goToWork);
+    stateMachineRouter.emit(ACTION.getFood, { coffee: true });
     expect(window.location.hash).toBe('#/work/lunchroom?coffee=true');
   });
 
   it('should invalid starting urls', () => {
-    const persistence = URLPersistence(createHashHistory());
+    const persistence = URLPersistence<STATE, TParams, ACTION>(createHashHistory());
     window.location.hash = '#/invalid?what=world&where=bla';
-    const stateMachineRouter: IMobxStateMachineRouter = MobxStateMachineRouter({
+    const stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
       states,
       currentState: {
-        name: 'HOME',
+        name: STATE.HOME,
         params: {
-          activity: null
-        }
+          activity: null,
+        },
       },
-      persistence
+      persistence,
     });
 
     expect(stateMachineRouter.currentState.name).toBe('HOME');
@@ -167,43 +188,43 @@ describe('with URL persistence', () => {
   });
 
   it('should allow resetting query params', () => {
-    const persistence = URLPersistence(createHashHistory());
+    const persistence = URLPersistence<STATE, TParams, ACTION>(createHashHistory());
     window.location.hash = '#/invalid?what=world&where=bla';
-    const stateMachineRouter: IMobxStateMachineRouter = MobxStateMachineRouter({
+    const stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
       states,
       currentState: {
-        name: 'HOME',
+        name: STATE.HOME,
         params: {
-          activity: 'initial'
-        }
+          activity: 'initial',
+        },
       },
-      persistence
+      persistence,
     });
-    stateMachineRouter.emit('goToWork', { activity: 'initial' });
+    stateMachineRouter.emit(ACTION.goToWork, { activity: 'initial' });
     expect(stateMachineRouter.currentState.params.activity).toBe('initial');
-    stateMachineRouter.emit('slack', { activity: 'daydreaming' });
+    stateMachineRouter.emit(ACTION.slack, { activity: 'daydreaming' });
     expect(stateMachineRouter.currentState.params.activity).toBe('daydreaming');
     expect(window.location.hash).toBe('#/work?activity=daydreaming');
-    stateMachineRouter.emit('slack', {});
+    stateMachineRouter.emit(ACTION.slack, {});
     expect(window.location.hash).toBe('#/work');
     expect(stateMachineRouter.currentState.params.activity).toBe(undefined);
   });
 
   it('should allow intecepting of state, which in turn doesn not set the URL', () => {
-    const persistence = URLPersistence(createHashHistory());
+    const persistence = URLPersistence<STATE, TParams, ACTION>(createHashHistory());
     window.location.hash = '#/';
-    const stateMachineRouter: IMobxStateMachineRouter = MobxStateMachineRouter({
+    const stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({
       states,
       currentState: {
-        name: 'HOME',
+        name: STATE.HOME,
         params: {
-          activity: null
-        }
+          activity: null,
+        },
       },
-      persistence
+      persistence,
     });
 
-    stateMachineRouter.emit('goToWork', { activity: 'kayaking' });
+    stateMachineRouter.emit(ACTION.goToWork, { activity: 'kayaking' });
     expect(window.location.hash).toBe('#/work?activity=kayaking');
     expect(stateMachineRouter.currentState.params.activity).toEqual('kayaking');
     expect(stateMachineRouter.currentState.name).toEqual('WORK');
@@ -211,12 +232,16 @@ describe('with URL persistence', () => {
       return null;
     });
 
-    stateMachineRouter.emit('goHome', { activity: 'walking' });
+    stateMachineRouter.emit(ACTION.goHome, { activity: 'walking' });
     expect(stateMachineRouter.currentState.params.activity).toEqual('kayaking');
     expect(stateMachineRouter.currentState.name).toEqual('WORK');
     expect(window.location.hash).toEqual('#/work?activity=kayaking');
   });
 });
+
+type TParams2 = TParams & {
+  bored?: string | null;
+};
 
 describe('custom getters/setters - boolean', () => {
   let persistence, stateMachineRouter;
@@ -229,20 +254,20 @@ describe('custom getters/setters - boolean', () => {
           },
           setter(value) {
             return value.toString();
-          }
-        }
-      }
+          },
+        },
+      },
     });
-    stateMachineRouter = MobxStateMachineRouter({
+    stateMachineRouter = MobxStateMachineRouter<STATE, TParams2, ACTION>({
       states,
       currentState: {
-        name: 'HOME',
+        name: STATE.HOME,
         params: {
           activity: null,
-          bored: null
-        }
+          bored: null,
+        },
       },
-      persistence
+      persistence,
     });
   });
 
@@ -253,7 +278,7 @@ describe('custom getters/setters - boolean', () => {
   });
 
   it('should allow users to specify custom serializer', () => {
-    stateMachineRouter.emit('goToWork', { bored: true });
+    stateMachineRouter.emit(ACTION.goToWork, { bored: true });
     expect(window.location.hash).toBe('#/work?bored=true');
   });
 
@@ -275,19 +300,23 @@ describe('custom getters/setters - array', () => {
           },
           setter(value: []) {
             return encodeURI(JSON.stringify(value));
-          }
-        }
-      }
+          },
+        },
+      },
     });
-    stateMachineRouter = MobxStateMachineRouter({
+    stateMachineRouter = MobxStateMachineRouter<
+      STATE,
+      TParams,
+      ACTION
+    >({
       states,
       currentState: {
-        name: 'HOME',
+        name: STATE.HOME,
         params: {
-          activity: null
-        }
+          activity: null,
+        },
       },
-      persistence
+      persistence,
     });
   });
 
@@ -298,7 +327,7 @@ describe('custom getters/setters - array', () => {
   });
 
   it('should allow users to specify custom serializer', () => {
-    stateMachineRouter.emit('goToWork', { activity: ['bus', 'walking'] });
+    stateMachineRouter.emit(ACTION.goToWork, { activity: ['bus', 'walking'] });
     expect(window.location.hash).toBe(
       '#/work?activity=%5B%22bus%22,%22walking%22%5D'
     );
@@ -309,7 +338,7 @@ describe('custom getters/setters - array', () => {
     await ms(10);
     expect(stateMachineRouter.currentState.params.activity).toEqual([
       'bus',
-      'walking'
+      'walking',
     ]);
   });
 });

--- a/packages/url-persistence/src/index.test.ts
+++ b/packages/url-persistence/src/index.test.ts
@@ -246,7 +246,7 @@ type TParams2 = TParams & {
 describe('custom getters/setters - boolean', () => {
   let persistence, stateMachineRouter;
   beforeEach(() => {
-    persistence = URLPersistence(createHashHistory(), {
+    persistence = URLPersistence<STATE, TParams2, ACTION>(createHashHistory(), {
       serializers: {
         bored: {
           getter(value) {


### PR DESCRIPTION
// state map can now be typed
const states: TStates<STATE, ACTION> = {}

// MSMR init will allow type checking throughout
const stateMachineRouter = MobxStateMachineRouter<STATE, TParams, ACTION>({})...

// persistence can now know about the state/params/actions a little better
persistence: URLPersistence<STATE, TParams2, ACTION>(createHashHistory()),